### PR TITLE
Patch to correctly find DLL and dependencies

### DIFF
--- a/xfoil/xfoil.py
+++ b/xfoil/xfoil.py
@@ -30,6 +30,12 @@ here = os.path.abspath(os.path.dirname(__file__))
 lib_path = glob.glob(os.path.join(here, 'libxfoil.*'))[0]
 lib_ext = lib_path[lib_path.rfind('.'):]
 
+for path in os.getenv('PATH').split(os.pathsep):
+    try:
+        os.add_dll_directory(path)
+    except:
+        pass
+
 fptr = POINTER(c_float)
 bptr = POINTER(c_bool)
 


### PR DESCRIPTION
Patch to correctly find DLL and dependencies in PATH variable on Windows.
Works, but the except: pass bit is a bit janky - for some reason, it throws an error after adding all the paths otherwise.

Fixes https://github.com/DARcorporation/xfoil-python/issues/10