### PR TITLE
Fix aseq skipping last angle

### DIFF
--- a/src/api.f90
+++ b/src/api.f90
@@ -388,8 +388,8 @@ contains
         use i_xfoil
         real(c_float), intent(in) :: a_start, a_end
         integer(c_int), intent(in) :: n_step
-        real(c_float), dimension(n_step), intent(inout) :: a_arr, cl_arr, cd_arr, cm_arr, cp_arr
-        logical(c_bool), dimension(n_step), intent(inout) :: conv_arr
+        real(c_float), dimension(n_step+1), intent(inout) :: a_arr, cl_arr, cd_arr, cm_arr, cp_arr
+        logical(c_bool), dimension(n_step+1), intent(inout) :: conv_arr
         integer :: i, j, iseqex, itmaxs
         real :: a0, da, nan
 
@@ -404,7 +404,7 @@ contains
         !----- initialize unconverged-point counter
         iseqex = 0
 
-        do i=1, n_step
+        do i=1, n_step+1
             ALFa = a0 + da * float(i - 1)
             if (abs(ALFa - AWAke)>1.0E-5) LWAke = .false.
             if (abs(ALFa - AVIsc)>1.0E-5) LVConv = .false.

--- a/xfoil/xfoil.py
+++ b/xfoil/xfoil.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+b, navigate to the main page of the repository.
+Under your repository name, click Issues.
+Click New issue.# -*- coding: utf-8 -*-
 #   Copyright (c) 2019 D. de Vries
 #
 #   This file is part of XFoil.
@@ -257,12 +259,12 @@ class XFoil(object):
         """
         n = abs(int((a_end - a_start) / a_step))
 
-        a = np.zeros(n, dtype=c_float)
-        cl = np.zeros(n, dtype=c_float)
-        cd = np.zeros(n, dtype=c_float)
-        cm = np.zeros(n, dtype=c_float)
-        cp = np.zeros(n, dtype=c_float)
-        conv = np.zeros(n, dtype=c_bool)
+        a = np.zeros(n+1, dtype=c_float)
+        cl = np.zeros(n+1, dtype=c_float)
+        cd = np.zeros(n+1, dtype=c_float)
+        cm = np.zeros(n+1, dtype=c_float)
+        cp = np.zeros(n+1, dtype=c_float)
+        conv = np.zeros(n+1, dtype=c_bool)
 
         self._lib.aseq(byref(c_float(a_start)), byref(c_float(a_end)), byref(c_int(n)),
                        a.ctypes.data_as(fptr), cl.ctypes.data_as(fptr),


### PR DESCRIPTION
Due to a bug in how the number of angles of attack in `aseq` is also used to increment the angles in the loop, this function skips the last angle in the sequence. A simple fix increasing the size of the arrays is proposed.