### PR TITLE
Fix for Mach number; Y coordinate outputting

### DIFF
--- a/src/api.f90
+++ b/src/api.f90
@@ -494,7 +494,7 @@ contains
         implicit none
 
         integer(c_int), intent(in) :: n_points
-        real(c_float), dimension(n_points), intent(inout) :: x_out, cp_out
+        real(c_float), dimension(n_points), intent(inout) :: x_out, y_out, cp_out
 
         real :: beta, bfac, cpcom, cpinc, den
         integer :: i

--- a/src/api.f90
+++ b/src/api.f90
@@ -487,7 +487,7 @@ contains
         get_n_cp = N
     end function get_n_cp
 
-    subroutine get_cp(x_out, cp_out, n_points) bind(c, name='get_cp')
+    subroutine get_cp(x_out, y_out, cp_out, n_points) bind(c, name='get_cp')
         use s_xfoil, only: comset
         use m_xoper
         use i_xfoil
@@ -508,6 +508,7 @@ contains
             den = beta + bfac * cpinc
             cp_out(i) = cpinc / den
             x_out(i) = X(i)
+            y_out(i) = Y(i)
         enddo
     end subroutine get_cp
 

--- a/src/api.f90
+++ b/src/api.f90
@@ -203,6 +203,7 @@ contains
 
         if (M /= MINf) then
             MINf = M
+            MINf1 = M
 
             call comset
             if (MINf>0.0 .and. show_output) write (*, 99003) CPStar, QSTar / QINf

--- a/xfoil/xfoil.py
+++ b/xfoil/xfoil.py
@@ -321,12 +321,15 @@ class XFoil(object):
         -------
         x : np.array
             X-coordinates
+        y : np.array
+            Y-coordinates
         cp : np.ndarray
             Pressure coefficients at the corresponding x-coordinates
         """
         n = self._lib.get_n_cp()
         x = np.zeros(n, dtype=c_float)
+        y = np.zeros(n, dtype=c_float)
         cp = np.zeros(n, dtype=c_float)
 
-        self._lib.get_cp(x.ctypes.data_as(fptr), cp.ctypes.data_as(fptr), byref(c_int(n)))
-        return x.astype(float), cp.astype(float)
+        self._lib.get_cp(x.ctypes.data_as(fptr), y.ctypes.data_as(fptr), cp.ctypes.data_as(fptr), byref(c_int(n)))
+        return x.astype(float), y.astype(float), cp.astype(float)


### PR DESCRIPTION
Fix for Mach number. (Issue #5)
Changes which allows for the y-coordinate to be returned in the get_cp subroutine.
